### PR TITLE
swapping first and last name of card title team to harmonize with the alphabetical order in About Us

### DIFF
--- a/_includes/team.html
+++ b/_includes/team.html
@@ -5,7 +5,7 @@
             <img src="{{site.url}}/assets/globe-model.svg" class="section-icon img-responsive" alt="steering committee icon">
                 <h3 class="col-sm-12 section-header">Core Developers</h3>
                 <p class="col-sm-12 support-paragraph">
-                    (in alphabetical order).
+                    (in alphabetical order)
                 </p>
             </div>
         </div>
@@ -14,8 +14,8 @@
       {% assign sorted = site.data.core.coredevs | sort: "last" %}
       {% for member in sorted %}
       <div class="col-md-4 material">
-        <img class="core-member-photo" alt="{{member.first}} {{member.last}}'s avatar picture" src='{{member.avatar}}' />
-        <h4 class="card-title">{{member.first}} {{member.last}}</h4>
+        <img class="core-member-photo" alt="{{member.last}} {{member.first}}'s avatar picture" src='{{member.avatar}}' />
+        <h4 class="card-title">{{member.last}}, {{member.first}}</h4>
         <p class="card-info">{{member.affiliation}}<br><a href="https://github.com/{{member.gh_handle}}" target="_blank"><em>@{{member.gh_handle}}</em></a> on GitHub</p>
       </div>
       {% endfor %}

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -14,7 +14,7 @@
       {% assign sorted = site.data.core.coredevs | sort: "last" %}
       {% for member in sorted %}
       <div class="col-md-4 material">
-        <img class="core-member-photo" alt="{{member.last}} {{member.first}}'s avatar picture" src='{{member.avatar}}' />
+        <img class="core-member-photo" alt="{{member.first}}, {{member.last}}'s avatar picture" src='{{member.avatar}}' />
         <h4 class="card-title">{{member.last}}, {{member.first}}</h4>
         <p class="card-info">{{member.affiliation}}<br><a href="https://github.com/{{member.gh_handle}}" target="_blank"><em>@{{member.gh_handle}}</em></a> on GitHub</p>
       </div>


### PR DESCRIPTION
Although I've seen that the jupyter.org website works with the current way, I think this makes more sense in terms of the alphabetical order desired.

ps.: It also removes a misplaced dot after the '(in alphabetical order)'