### PR TITLE
alphabetizing module names in Documentation

### DIFF
--- a/_data/documentation.yml
+++ b/_data/documentation.yml
@@ -9,24 +9,24 @@ lib:
 
 PySAL explore:
   esda: https://esda.readthedocs.io/en/latest/
-  pointpats: https://pointpats.readthedocs.io/en/latest/
-  spaghetti: https://pysal-spaghetti.readthedocs.io/en/latest/
   giddy: https://giddy.readthedocs.io/en/latest/
-  region: https://github.com/pysal/region
   inequality:  https://inequality.readthedocs.io/en/latest/ 
+  pointpats: https://pointpats.readthedocs.io/en/latest/
   segregation: https://github.com/pysal/segregation
+  spaghetti: https://pysal-spaghetti.readthedocs.io/en/latest/
+  region: https://github.com/pysal/region
 
 PySAL model:
-  spreg: https://github.com/pysal/spreg
-  spint: https://github.com/pysal/spint
-  spglm: https://github.com/pysal/spglm
   mgwr:  https://mgwr.readthedocs.io/en/latest/
+  spglm: https://github.com/pysal/spglm
+  spint: https://github.com/pysal/spint
+  spreg: https://github.com/pysal/spreg
   spvcm: https://github.com/pysal/spvcm
 
 PySAL viz:
+  legendgram: https://github.com/pysal/legendgram
   mapclassify: https://mapclassify.readthedocs.io/en/stable/
   splot: https://splot.readthedocs.io/en/latest/
-  legendgram: https://github.com/pysal/legendgram
 
 PySAL Notebooks:
   notebooks: http://pysal.org/notebooks/intro.html 


### PR DESCRIPTION
Alphabetizing submodule names on the [Documentation](http://pysal.org/documentation) page