### PR TITLE
typo in spaghetti-conda-forge link

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,6 +1,6 @@
 - name: spaghetti 1.3
   date: 2019-05-22
-  summary: <a href="https://pysal-spaghetti.readthedocs.io/en/latest/">spaghetti 1.3</a> released on <a href="https://pypi.org/project/spaghetti/1.3/">PyPI</a> and <a https://anaconda.org/conda-forge/spaghetti">conda-forge</a>. This is the first version that officially supports Python 3.6 and 3.7 exclusively.
+  summary: <a href="https://pysal-spaghetti.readthedocs.io/en/latest/">spaghetti 1.3</a> released on <a href="https://pypi.org/project/spaghetti/1.3/">PyPI</a> and <a href="https://anaconda.org/conda-forge/spaghetti">conda-forge</a>. This is the first version that officially supports Python 3.6 and 3.7 exclusively.
 
 - name: spaghetti 1.2
   date: 2019-05-11


### PR DESCRIPTION
Correcting bad syntax in link for `spaghetti` to `conda-forge` .