### PR TITLE
spaghetti v1.4.1 news

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,4 +1,8 @@
-- name: mapclassify 2.2.0 
+- name: spaghetti 1.4.1
+    date: 2020-01-25
+    summary: <a href="https://pysal.org/spaghetti/">spaghetti 1.4.1</a> released on <a href="https://pypi.org/project/spaghetti/1.4.1/">PyPI</a> and <a href="https://anaconda.org/conda-forge/spaghetti">conda-forge</a>. This release includes new functionality with handling PySAL geometries and shortest path extraction, among other <a href="https://github.com/pysal/spaghetti/releases/tag/v1.4.1">enhancements and bug fixes</a>.
+
+- name: mapclassify 2.2.0
   date: 2020-01-04
   summary: <a href="https://pysal.org/mapclassify/">mapclassify 2.2.0</a> released on <a href="https://pypi.org/project/mapclassify/2.2.0/">PyPI</a>. This release includes <a href="https://github.com/sjsrey/geopandas/blob/legendkwds/examples/choro_legends.ipynb">new legend formatting functionality</a> among other <a href="https://github.com/pysal/mapclassify/releases/tag/v2.2.0">enhancements and bug fixes</a>.
 


### PR DESCRIPTION
This PR adds the release news for [spaghetti `v1.4.1`](https://github.com/pysal/spaghetti/releases/tag/v1.4.1).