### PR TITLE
spaghetti news v1.4.2.post2

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,6 +1,6 @@
-- name: spaghetti 1.4.2post1
+- name: spaghetti 1.4.2.post2
   date: 2020-02-24
-  summary: <a href="https://pysal.org/spaghetti/">spaghetti 1.4.2post1</a> released on <a href="https://pypi.org/project/spaghetti/1.4.2.post1/">PyPI</a> and <a href="https://anaconda.org/conda-forge/spaghetti">conda-forge</a>. This release focuses on improved testing and functionality, specifically component and shortest path feature extraction. See the <a href="https://github.com/pysal/spaghetti/releases/tag/v1.4.2">v1.4.2</a> and <a href="https://github.com/pysal/spaghetti/releases/tag/v1.4.2post1">v1.4.2post1</a> release notes for more details.
+  summary: <a href="https://pysal.org/spaghetti/">spaghetti 1.4.2.post2</a> released on <a href="https://pypi.org/project/spaghetti/1.4.2.post2/">PyPI</a> and <a href="https://anaconda.org/conda-forge/spaghetti">conda-forge</a>. This release focuses on improved testing and functionality, specifically component and shortest path feature extraction. See the <a href="https://github.com/pysal/spaghetti/releases/tag/v1.4.2">v1.4.2</a>, <a href="https://github.com/pysal/spaghetti/releases/tag/v1.4.2post1">v1.4.2.post1</a>, and <a href="https://github.com/pysal/spaghetti/releases/tag/v1.4.2.post2">v1.4.2.post2</a> release notes for more details.
 
 - name: pysal 2.2.0
   date: 2020-02-13

--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,3 +1,7 @@
+- name: spaghetti 1.4.2post1
+  date: 2020-02-24
+  summary: <a href="https://pysal.org/spaghetti/">spaghetti 1.4.2post1</a> released on <a href="https://pypi.org/project/spaghetti/1.4.2.post1/">PyPI</a> and <a href="https://anaconda.org/conda-forge/spaghetti">conda-forge</a>. This release focuses on improved testing and functionality, specifically component and shortest path feature extraction. See the <a href="https://github.com/pysal/spaghetti/releases/tag/v1.4.2">v1.4.2</a> and <a href="https://github.com/pysal/spaghetti/releases/tag/v1.4.2post1">v1.4.2post1</a> release notes for more details.
+
 - name: pysal 2.2.0
   date: 2020-02-13
   summary: <a href="https://pysal.org/pysal/">pysal 2.2.0</a> released on <a href="https://pypi.org/project/pysal/2.2.0/">PyPI</a>. <a href="https://github.com/pysal/pysal/releases/tag/v2.2.0">Release Notes</a>.


### PR DESCRIPTION
This PR update `spaghetti` release news: spaghetti news ~~`v1.4.2post1`~~ `v1.4.2.post2`.