### PR TITLE
update docs link for giddy

### DIFF
--- a/_data/documentation.yml
+++ b/_data/documentation.yml
@@ -10,7 +10,7 @@ lib:
 
 PySAL explore:
   esda: https://pysal.org/esda
-  giddy: https://giddy.readthedocs.io/en/latest/
+  giddy: https://pysal.org/giddy
   inequality:  https://inequality.readthedocs.io/en/latest/ 
   pointpats: https://pointpats.readthedocs.io/en/latest/
   segregation: https://github.com/pysal/segregation


### PR DESCRIPTION
The docs of giddy have migrated from readthedocs to github page https://pysal.org/giddy