### PR TITLE
addressing broken link (#160)

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@ permalink: /
            </a>
        </div>
        <div class="col-sm-3 col-xs-12">
-        <a href="http://nbviewer.jupyter.org/github/pysal/giddy/blob/master/notebooks/directional.ipynb" class="thumbnail">
+        <a href="http://pysal.org/notebooks/explore/giddy/directional.html" class="thumbnail">
        <img src="assets/images/rose_conditional.png" class="img-responsive center-block">
                <div class="caption text-center">
                <h6>Rose diagram (directional LISAs)</h6>


### PR DESCRIPTION
addressing broken link to `giddy/directional` raised in #160.